### PR TITLE
refactor: rename mod from "Crime Remover" to "Crime Adjuster"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 /.idea/
 /CrimeRemover.sln.DotSettings.user
+node_modules

--- a/Mod.cs
+++ b/Mod.cs
@@ -32,8 +32,9 @@ namespace CrimeRemover
 {
     public class Mod : IMod
     {
-        public const string Name = "RollW_CrimeRemover";
-        private static readonly ILog LOG = LogManager.GetLogger($"{Name}.Mod")
+        public const string Name = "RollW_CrimeAdjuster";
+        private static readonly ILog LOG = LogManager
+            .GetLogger($"{Name}.Mod")
             .SetShowsErrorsInUI(false);
 
         public static CrimeSetting Setting { get; private set; }
@@ -53,8 +54,7 @@ namespace CrimeRemover
 
         private void SetupOnLoad(UpdateSystem updateSystem)
         {
-            if (GameManager.instance.modManager
-                .TryGetExecutableAsset(this, out var asset))
+            if (GameManager.instance.modManager.TryGetExecutableAsset(this, out var asset))
             {
                 LOG.Info($"Current mod asset at {asset.path}");
             }
@@ -62,25 +62,26 @@ namespace CrimeRemover
             Setting.RegisterInOptionsUI();
             Localizations.LoadTranslations();
 
-            AssetDatabase.global.LoadSettings(Name,
-                Setting, new CrimeSetting(this)
-            );
+            AssetDatabase.global.LoadSettings(Name, Setting, new CrimeSetting(this));
 
             LOG.Info($"Load settings: {Setting.ToJSONString()}");
 
-            updateSystem.UpdateAfter<CrimeNotificationRemoverSystem>(SystemUpdatePhase.Deserialize);
-            updateSystem.UpdateAfter<CrimeNotificationRemoverSystem>(SystemUpdatePhase.GameSimulation);
+            updateSystem.UpdateAfter<CrimeNotificationAdjusterSystem>(
+                SystemUpdatePhase.Deserialize
+            );
+            updateSystem.UpdateAfter<CrimeNotificationAdjusterSystem>(
+                SystemUpdatePhase.GameSimulation
+            );
             updateSystem.UpdateAfter<CriminalRemoveSystem>(SystemUpdatePhase.Deserialize);
             updateSystem.UpdateAfter<CriminalRemoveSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<AddCriminalRemoveSystem>(SystemUpdatePhase.Deserialize);
             updateSystem.UpdateAfter<AddCriminalRemoveSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<CrimeRemoverSystem>(SystemUpdatePhase.Deserialize);
-            updateSystem.UpdateAfter<CrimeRemoverSystem>(SystemUpdatePhase.GameSimulation);
+            updateSystem.UpdateAfter<CrimeAdjusterSystem>(SystemUpdatePhase.Deserialize);
+            updateSystem.UpdateAfter<CrimeAdjusterSystem>(SystemUpdatePhase.GameSimulation);
 
             updateSystem.UpdateAfter<MarkCriminalSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<PoliceRequestSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAt<UIBindingSystem>(SystemUpdatePhase.UIUpdate);
-
         }
 
         public void OnDispose()

--- a/Setting/CrimeSetting.cs
+++ b/Setting/CrimeSetting.cs
@@ -31,13 +31,13 @@ public class CrimeSetting(IMod mod) : ModSetting(mod)
     private const string Experimental = "Experimental";
 
     /**
-     * Enable or disable the crime remover
+     * Enable or disable the crime adjuster
      */
-    public bool EnableCrimeRemover { get; set; } = true;
+    public bool EnableCrimeAdjuster { get; set; } = true;
 
     public bool IsDisabled()
     {
-        return !EnableCrimeRemover;
+        return !EnableCrimeAdjuster;
     }
 
     [SettingsUISection(Experimental)]
@@ -47,9 +47,9 @@ public class CrimeSetting(IMod mod) : ModSetting(mod)
     /**
      * Set the global buildings crime percentage
      *
-     * Must be between 0 and 100
+     * Values below 100 reduce crime, values above 100 increase crime
      */
-    [SettingsUISlider(max = 100, min = 0, step = 1)]
+    [SettingsUISlider(max = 300, min = 0, step = 5)]
     [SettingsUISection(Experimental)]
     public float CrimeBuildingPercentage { get; set; } = 0;
 
@@ -62,8 +62,10 @@ public class CrimeSetting(IMod mod) : ModSetting(mod)
 
     /**
      * The scale of the building crime percentage
+     *
+     * Values below 100 reduce crime, values above 100 increase crime
      */
-    [SettingsUISlider(max = 100, min = 0, step = 1)]
+    [SettingsUISlider(max = 500, min = 0, step = 5)]
     [SettingsUISection(Experimental)]
     public float CrimePercentage { get; set; } = 0;
 
@@ -85,17 +87,17 @@ public class CrimeSetting(IMod mod) : ModSetting(mod)
         {
             NotificationType.AlwaysRemove => true,
             NotificationType.NeverRemove => false,
-            NotificationType.OnlyEnable => EnableCrimeRemover,
+            NotificationType.OnlyEnable => EnableCrimeAdjuster,
             // if the building crime percentage is greater than 0,
             // then we will not remove the notification
-            NotificationType.OnlyPercentage => EnableCrimeRemover && CrimePercentage == 0,
-            _ => false
+            NotificationType.OnlyPercentage => EnableCrimeAdjuster && CrimePercentage == 0,
+            _ => false,
         };
     }
 
     public override void SetDefaults()
     {
-        EnableCrimeRemover = true;
+        EnableCrimeAdjuster = true;
         CrimeBuildingPercentage = 0;
         CrimePercentage = 0;
         MaxCrime = 25000;

--- a/Setting/Localizations.cs
+++ b/Setting/Localizations.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2024 RollW
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,84 +29,167 @@ namespace CrimeRemover.Setting
         private static readonly Translation[] Translations =
         [
             new Translation("Options.SECTION[CrimeRemover.CrimeRemover.Mod]")
-                .AddTranslation(LocaleCode.EnUs, "Crime Remover")
-                .AddTranslation(LocaleCode.ZhHans, "犯罪移除器")
-                .AddTranslation(LocaleCode.ZhHant, "犯罪移除器"),
-            new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.EnableCrimeRemover]")
-                .AddTranslation(LocaleCode.EnUs, "Enable Crime Remover")
-                .AddTranslation(LocaleCode.ZhHans, "启用犯罪移除器")
-                .AddTranslation(LocaleCode.ZhHant, "啟用犯罪移除器"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.EnableCrimeRemover]")
-                .AddTranslation(LocaleCode.EnUs,
-                    "Enable or disable the crime remover. When disabled, the set crime values will not be removed, " +
-                    "but no new crime values will be set or removed")
-                .AddTranslation(LocaleCode.ZhHans, "在此启用或禁用犯罪移除器。在禁用时，已设置的犯罪值不会被移除，但不会再继续设置或移除新的犯罪值")
-                .AddTranslation(LocaleCode.ZhHant, "在此啟用或禁用犯罪移除器。在禁用時，已設置的犯罪值不會被移除，但不會再繼續設置或移除新的犯罪值"),
+                .AddTranslation(LocaleCode.EnUs, "Crime Adjuster")
+                .AddTranslation(LocaleCode.ZhHans, "犯罪调节器")
+                .AddTranslation(LocaleCode.ZhHant, "犯罪調節器"),
             new Translation(
-                    "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveCriminals]")
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.EnableCrimeAdjuster]"
+            )
+                .AddTranslation(LocaleCode.EnUs, "Enable Crime Adjuster")
+                .AddTranslation(LocaleCode.ZhHans, "启用犯罪调节器")
+                .AddTranslation(LocaleCode.ZhHant, "啟用犯罪調節器"),
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.EnableCrimeAdjuster]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Enable or disable the crime adjuster. When disabled, the crime values will not be adjusted, "
+                        + "but no new crime values will be set or modified"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "在此启用或禁用犯罪调节器。在禁用时，犯罪值不会被调整，但不会再继续设置或修改新的犯罪值"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "在此啟用或禁用犯罪調節器。在禁用時，犯罪值不會被調整，但不會再繼續設置或修改新的犯罪值"
+                ),
+            new Translation(
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveCriminals]"
+            )
                 .AddTranslation(LocaleCode.EnUs, "Remove Criminals")
                 .AddTranslation(LocaleCode.ZhHans, "移除罪犯")
                 .AddTranslation(LocaleCode.ZhHant, "移除罪犯"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveCriminals]")
-                .AddTranslation(LocaleCode.EnUs, "When enabled, all criminals will be continuously removed. " +
-                                                 "Manually marked criminals will not be removed.")
-                .AddTranslation(LocaleCode.ZhHans, "启用后，将持续移除所有罪犯。被手动标记的罪犯不会被移除。")
-                .AddTranslation(LocaleCode.ZhHant, "啟用後，將持續移除所有罪犯。被手動標記的罪犯不會被移除。"),
-            new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimeBuildingPercentage]")
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveCriminals]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "When enabled, all criminals will be continuously removed. "
+                        + "Manually marked criminals will not be removed."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "启用后，将持续移除所有罪犯。被手动标记的罪犯不会被移除。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "啟用後，將持續移除所有罪犯。被手動標記的罪犯不會被移除。"
+                ),
+            new Translation(
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimeBuildingPercentage]"
+            )
                 .AddTranslation(LocaleCode.EnUs, "Building Crime Percentage")
                 .AddTranslation(LocaleCode.ZhHans, "建筑犯罪百分比")
                 .AddTranslation(LocaleCode.ZhHant, "建築犯罪百分比"),
             new Translation(
-                    "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimeBuildingPercentage]")
-                .AddTranslation(LocaleCode.EnUs, "Set the global buildings crime percentage")
-                .AddTranslation(LocaleCode.ZhHans, "设置全局建筑犯罪百分比")
-                .AddTranslation(LocaleCode.ZhHant, "設置全局建築犯罪百分比"),
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimeBuildingPercentage]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Set the global buildings crime percentage. Values below 100% reduce crime, values above 100% increase crime."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "设置全局建筑犯罪百分比。值低于100%减少犯罪，高于100%增加犯罪。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "設置全局建築犯罪百分比。值低於100%減少犯罪，高於100%增加犯罪。"
+                ),
             new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.MaxCrime]")
                 .AddTranslation(LocaleCode.EnUs, "Max Crime")
                 .AddTranslation(LocaleCode.ZhHans, "最大犯罪值")
                 .AddTranslation(LocaleCode.ZhHant, "最大犯罪值"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.MaxCrime]")
-                .AddTranslation(LocaleCode.EnUs, "The maximum crime value. When this value is greater than 25000, " +
-                                                 "it may cause the city crime rate to be greater than 100%.")
-                .AddTranslation(LocaleCode.ZhHans, "设置最大犯罪值。此值大于 25000 时可能导致城市犯罪率大于 100%。")
-                .AddTranslation(LocaleCode.ZhHant, "設置最大犯罪值。此值大於 25000 時可能導致城市犯罪率大於 100%。"),
-            new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimePercentage]")
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.MaxCrime]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "The maximum crime value. When this value is greater than 25000, "
+                        + "it may cause the city crime rate to be greater than 100%."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "设置最大犯罪值。此值大于 25000 时可能导致城市犯罪率大于 100%。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "設置最大犯罪值。此值大於 25000 時可能導致城市犯罪率大於 100%。"
+                ),
+            new Translation(
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimePercentage]"
+            )
                 .AddTranslation(LocaleCode.EnUs, "Building Crime Multiplier Rate")
                 .AddTranslation(LocaleCode.ZhHans, "建筑犯罪值乘率")
                 .AddTranslation(LocaleCode.ZhHant, "建築犯罪值乘率"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimePercentage]")
-                .AddTranslation(LocaleCode.EnUs, "The scale of the building crime percentage, " +
-                                                 "the final building crime value is Building Crime Multiplier Rate * Max Crime")
-                .AddTranslation(LocaleCode.ZhHans, "建筑犯罪值乘率，最终建筑犯罪值为 建筑犯罪值乘率 * 最大犯罪值")
-                .AddTranslation(LocaleCode.ZhHant, "建築犯罪值乘率，最終建築犯罪值為 建築犯罪值乘率 * 最大犯罪值"),
-            new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.PolicePatrol]")
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.CrimePercentage]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "The scale of the building crime percentage. Values below 100% reduce crime, values above 100% increase crime. "
+                        + "The final building crime value is Building Crime Multiplier Rate * Max Crime / 100"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "建筑犯罪值乘率。值低于100%减少犯罪，高于100%增加犯罪。最终建筑犯罪值为 建筑犯罪值乘率 * 最大犯罪值 / 100"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "建築犯罪值乘率。值低於100%減少犯罪，高於100%增加犯罪。最終建築犯罪值為 建築犯罪值乘率 * 最大犯罪值 / 100"
+                ),
+            new Translation(
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.PolicePatrol]"
+            )
                 .AddTranslation(LocaleCode.EnUs, "Enable Police Patrol")
                 .AddTranslation(LocaleCode.ZhHans, "启用警察巡逻")
                 .AddTranslation(LocaleCode.ZhHant, "啟用警察巡邏"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.PolicePatrol]")
-                .AddTranslation(LocaleCode.EnUs,
-                    "Enable police patrol. When disabled, the police will no longer patrol." +
-                    "If you set the building crime value greater than 0, as this mod will always set the crime value, " +
-                    "the police patrol will not reduce the building crime value, " +
-                    "it may reduce system load after disabling. " +
-                    "Note: Disabling this option will not prevent the police from arriving at the \"Crime Scene\".")
-                .AddTranslation(LocaleCode.ZhHans,
-                    "启用警察巡逻。禁用后，警察将不再巡逻。" +
-                    "如果你设置了建筑犯罪值大于0，由于本Mod会始终设置犯罪值，警察巡逻无法使建筑犯罪值降低，禁用后或可降低部分系统占用。" +
-                    "注意：禁用本选项不会阻止警察到达「犯罪现场」。")
-                .AddTranslation(LocaleCode.ZhHant,
-                    "啟用警察巡邏。禁用後，警察將不再巡邏。" +
-                    "如果你設置了建築犯罪值大于0，由於本Mod會始終設置犯罪值，警察巡邏無法使建築犯罪值降低，禁用後或可降低部分系統佔用。" +
-                    "注意：禁用本選項不會阻止警察到達「犯罪現場」。"),
-            new Translation("Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveNotification]")
-                .AddTranslation(LocaleCode.EnUs, "Remove Crime Scene")
-                .AddTranslation(LocaleCode.ZhHans, "移除犯罪现场")
-                .AddTranslation(LocaleCode.ZhHant, "移除犯罪現場"),
-            new Translation("Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveNotification]")
-                .AddTranslation(LocaleCode.EnUs, "Remove the \"Crime Scene\" event. " +
-                                                 "Removing the notification also prevents the event from occurring.")
-                .AddTranslation(LocaleCode.ZhHans, "移除「犯罪现场」事件。移除通知同时阻止事件产生。")
-                .AddTranslation(LocaleCode.ZhHant, "移除「犯罪現場」事件。移除通知同時阻止事件產生。"),
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.PolicePatrol]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Enable police patrol. When disabled, the police will no longer patrol."
+                        + "If you set the building crime value greater than 0, as this mod will always set the crime value, "
+                        + "the police patrol will not reduce the building crime value, "
+                        + "it may reduce system load after disabling. "
+                        + "Note: Disabling this option will not prevent the police from arriving at the \"Crime Scene\"."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "启用警察巡逻。禁用后，警察将不再巡逻。"
+                        + "如果你设置了建筑犯罪值大于0，由于本Mod会始终设置犯罪值，警察巡逻无法使建筑犯罪值降低，禁用后或可降低部分系统占用。"
+                        + "注意：禁用本选项不会阻止警察到达「犯罪现场」。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "啟用警察巡邏。禁用後，警察將不再巡邏。"
+                        + "如果你設置了建築犯罪值大于0，由於本Mod會始終設置犯罪值，警察巡邏無法使建築犯罪值降低，禁用後或可降低部分系統佔用。"
+                        + "注意：禁用本選項不會阻止警察到達「犯罪現場」。"
+                ),
+            new Translation(
+                "Options.OPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveNotification]"
+            )
+                .AddTranslation(LocaleCode.EnUs, "Crime Scene Notifications")
+                .AddTranslation(LocaleCode.ZhHans, "犯罪现场通知")
+                .AddTranslation(LocaleCode.ZhHant, "犯罪現場通知"),
+            new Translation(
+                "Options.OPTION_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.CrimeSetting.RemoveNotification]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Control the \"Crime Scene\" event notifications. "
+                        + "Removing the notification also prevents the event from occurring."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "控制「犯罪现场」事件通知。移除通知同时阻止事件产生。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "控制「犯罪現場」事件通知。移除通知同時阻止事件產生。"
+                ),
             new Translation("Options.CrimeRemover.CrimeRemover.Mod.NOTIFICATIONTYPE[AlwaysRemove]")
                 .AddTranslation(LocaleCode.EnUs, "Always remove")
                 .AddTranslation(LocaleCode.ZhHans, "始终移除")
@@ -120,8 +203,12 @@ namespace CrimeRemover.Setting
                 .AddTranslation(LocaleCode.ZhHans, "仅在启用时移除")
                 .AddTranslation(LocaleCode.ZhHant, "僅在啟用時移除"),
             new Translation(
-                    "Options.CrimeRemover.CrimeRemover.Mod.NOTIFICATIONTYPE[OnlyPercentage]")
-                .AddTranslation(LocaleCode.EnUs, "Only remove when the building crime percentage is 0")
+                "Options.CrimeRemover.CrimeRemover.Mod.NOTIFICATIONTYPE[OnlyPercentage]"
+            )
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Only remove when the building crime percentage is 0"
+                )
                 .AddTranslation(LocaleCode.ZhHans, "仅在建筑犯罪百分比为 0 时移除")
                 .AddTranslation(LocaleCode.ZhHant, "僅在建築犯罪百分比為 0 時移除"),
             new Translation("Options.GROUP[CrimeRemover.CrimeRemover.Mod.Experimental]")
@@ -129,44 +216,67 @@ namespace CrimeRemover.Setting
                 .AddTranslation(LocaleCode.ZhHans, "实验性")
                 .AddTranslation(LocaleCode.ZhHant, "實驗性"),
             new Translation("Options.GROUP_DESCRIPTION[CrimeRemover.CrimeRemover.Mod.Experimental]")
-                .AddTranslation(LocaleCode.EnUs, "Experimental features, may cause game instability")
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Experimental features, may cause game instability"
+                )
                 .AddTranslation(LocaleCode.ZhHans, "实验性功能，可能会导致游戏不稳定")
                 .AddTranslation(LocaleCode.ZhHant, "實驗性功能，可能會導致遊戲不穩定"),
-            new Translation("CrimeRemover.CRIME_REMOVER")
-                .AddTranslation(LocaleCode.EnUs, "Crime Remover")
-                .AddTranslation(LocaleCode.ZhHans, "犯罪移除器")
-                .AddTranslation(LocaleCode.ZhHant, "犯罪移除器"),
+            new Translation("CrimeRemover.CRIME_ADJUSTER")
+            {
+                ["en-US"] = "Crime Adjuster",
+                ["zh-CN"] = "犯罪调节器",
+                ["zh-TW"] = "犯罪調節器",
+            },
             new Translation("CrimeRemover.MarkCriminal")
                 .AddTranslation(LocaleCode.EnUs, "Mark as Criminal")
                 .AddTranslation(LocaleCode.ZhHans, "标记为罪犯")
                 .AddTranslation(LocaleCode.ZhHant, "標記為罪犯"),
             new Translation("CrimeRemover.MarkCriminal.DESC")
-                .AddTranslation(LocaleCode.EnUs,
-                    "Mark the currently selected citizen as a criminal, remove the current occupation and convert it to a criminal. " +
-                    "There is a certain delay in the conversion process.")
-                .AddTranslation(LocaleCode.ZhHans, "将当前选中的市民标记为罪犯，将移除当前职业并将其转为罪犯。转换过程存在一定的延迟。")
-                .AddTranslation(LocaleCode.ZhHant, "將當前選中的市民標記為罪犯，將移除當前職業並將其轉為罪犯。轉換過程存在一定的延遲。"),
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Mark the currently selected citizen as a criminal, remove the current occupation and convert it to a criminal. "
+                        + "There is a certain delay in the conversion process."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "将当前选中的市民标记为罪犯，将移除当前职业并将其转为罪犯。转换过程存在一定的延迟。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "將當前選中的市民標記為罪犯，將移除當前職業並將其轉為罪犯。轉換過程存在一定的延遲。"
+                ),
             new Translation("CrimeRemover.RemoveCriminal")
                 .AddTranslation(LocaleCode.EnUs, "Remove Criminal Mark")
                 .AddTranslation(LocaleCode.ZhHans, "移除罪犯标记")
                 .AddTranslation(LocaleCode.ZhHant, "移除罪犯標記"),
             new Translation("CrimeRemover.RemoveCriminal.DESC")
-                .AddTranslation(LocaleCode.EnUs,
-                    "Remove the criminal mark of the currently selected citizen, restore it to a normal citizen," +
-                    " but the original occupation will not be restored.")
-                .AddTranslation(LocaleCode.ZhHans, "移除当前选中市民的罪犯标记，将其恢复为普通市民，但原有职业不会恢复。")
-                .AddTranslation(LocaleCode.ZhHant, "移除當前選中市民的罪犯標記，將其恢復為普通市民，但原有職業不會恢復。"),
+                .AddTranslation(
+                    LocaleCode.EnUs,
+                    "Remove the criminal mark of the currently selected citizen, restore it to a normal citizen,"
+                        + " but the original occupation will not be restored."
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHans,
+                    "移除当前选中市民的罪犯标记，将其恢复为普通市民，但原有职业不会恢复。"
+                )
+                .AddTranslation(
+                    LocaleCode.ZhHant,
+                    "移除當前選中市民的罪犯標記，將其恢復為普通市民，但原有職業不會恢復。"
+                ),
         ];
 
         public static void LoadTranslations()
         {
-            foreach (var supportedLocale in GameManager.instance
-                         .localizationManager.GetSupportedLocales())
+            foreach (
+                var supportedLocale in GameManager.instance.localizationManager.GetSupportedLocales()
+            )
             {
                 var locale = FromString(supportedLocale);
                 var dictionary = Translation.ToDictionary(Translations, locale);
                 GameManager.instance.localizationManager.AddSource(
-                    supportedLocale, new MemorySource(dictionary)
+                    supportedLocale,
+                    new MemorySource(dictionary)
                 );
             }
         }
@@ -178,7 +288,7 @@ namespace CrimeRemover.Setting
                 "en-US" => LocaleCode.EnUs,
                 "zh-HANS" => LocaleCode.ZhHans,
                 "zh-HANT" => LocaleCode.ZhHant,
-                _ => LocaleCode.EnUs
+                _ => LocaleCode.EnUs,
             };
         }
     }

--- a/Setting/NotificationType.cs
+++ b/Setting/NotificationType.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2024 RollW
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,24 +23,22 @@ namespace CrimeRemover.Setting;
 public enum NotificationType
 {
     /**
-     * Always remove the notification, regardless of whether
-     * the mod is enabled or not.
+     * Always adjust notifications regardless of mod status
      */
     AlwaysRemove,
 
     /**
-     * Never remove the notification.
+     * Never adjust notifications regardless of mod status
      */
     NeverRemove,
 
     /**
-     * Only remove the notification when the mod is enabled.
+     * Only adjust notifications when mod is enabled
      */
     OnlyEnable,
 
     /**
-     * Only remove the notification when the mod is enabled
-     * and the building crime percentage is zero.
+     * Only adjust notifications when crime percentage is set
      */
-    OnlyPercentage
+    OnlyPercentage,
 }

--- a/System/AddCriminalRemoveSystem.cs
+++ b/System/AddCriminalRemoveSystem.cs
@@ -35,7 +35,7 @@ public sealed partial class AddCriminalRemoveSystem : GameSystemBase
 
     protected override void OnUpdate()
     {
-        if (!Mod.Setting.EnableCrimeRemover || !Mod.Setting.RemoveCriminals)
+        if (!Mod.Setting.EnableCrimeAdjuster || !Mod.Setting.RemoveCriminals)
         {
             return;
         }

--- a/System/CrimeNotificationRemoverSystem.cs
+++ b/System/CrimeNotificationRemoverSystem.cs
@@ -30,7 +30,7 @@ using Unity.Entities;
 
 namespace CrimeRemover.System;
 
-public sealed partial class CrimeNotificationRemoverSystem : GameSystemBase
+public sealed partial class CrimeNotificationAdjusterSystem : GameSystemBase
 {
     private EntityQuery _policeConfigurationQuery;
     private EntityQuery _notificationsQuery;
@@ -102,7 +102,7 @@ public sealed partial class CrimeNotificationRemoverSystem : GameSystemBase
     {
         base.OnCreate();
 
-        Mod.GetLogger().Info("Setup CrimeNotificationRemoverSystem.");
+        Mod.GetLogger().Info("Setup CrimeNotificationAdjusterSystem.");
 
         _policeConfigurationQuery = GetEntityQuery(
             ComponentType.ReadOnly<PoliceConfigurationData>(),

--- a/System/CrimeRemoverSystem.cs
+++ b/System/CrimeRemoverSystem.cs
@@ -28,13 +28,13 @@ using Unity.Entities;
 
 namespace CrimeRemover.System;
 
-public sealed partial class CrimeRemoverSystem : GameSystemBase
+public sealed partial class CrimeAdjusterSystem : GameSystemBase
 {
     private EntityQuery _crimeProducersQuery;
 
     protected override void OnUpdate()
     {
-        if (!Mod.Setting.EnableCrimeRemover)
+        if (!Mod.Setting.EnableCrimeAdjuster)
         {
             return;
         }
@@ -69,14 +69,12 @@ public sealed partial class CrimeRemoverSystem : GameSystemBase
                 continue;
             }
 
-            if (crimeProducer.m_Crime <= 0)
+            if (crimePercentage <= 0 && crimeProducer.m_Crime > 0)
             {
-                continue;
+                crimeProducer.m_Crime = 0;
+                crimeProducer = CheckCrimePatrolRequest(crimeProducer);
+                EntityManager.SetComponentData(entity, crimeProducer);
             }
-
-            crimeProducer.m_Crime = 0;
-            crimeProducer = CheckCrimePatrolRequest(crimeProducer);
-            EntityManager.SetComponentData(entity, crimeProducer);
         }
     }
 

--- a/System/CriminalMark.cs
+++ b/System/CriminalMark.cs
@@ -23,6 +23,4 @@ using Unity.Entities;
 
 namespace CrimeRemover.System;
 
-public struct CriminalMark : IComponentData, IEmptySerializable
-{
-}
+public struct CriminalMark : IComponentData, IEmptySerializable { }

--- a/System/CriminalRemoveSystem.cs
+++ b/System/CriminalRemoveSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class CriminalRemoveSystem : GameSystemBase
 
     protected override void OnUpdate()
     {
-        if (!Mod.Setting.EnableCrimeRemover || !Mod.Setting.RemoveCriminals)
+        if (!Mod.Setting.EnableCrimeAdjuster || !Mod.Setting.RemoveCriminals)
         {
             return;
         }

--- a/UI/src/mods/MarkCriminalComponent.tsx
+++ b/UI/src/mods/MarkCriminalComponent.tsx
@@ -69,7 +69,7 @@ const MarkCriminalComponent = () => {
     return showCitizenPanel ? (<PanelSection>
         <div className="actions-section_X1x info-row_QQ9">
             <div className="left_RyE uppercase_f0y">
-                {translate(getTranslationKeyOf("CRIME_REMOVER"), "Crime Remover")}
+                {translate(getTranslationKeyOf("CRIME_ADJUSTER"), "Crime Adjuster")}
             </div>
             <Tooltip tooltip={
                 <div>


### PR DESCRIPTION
This commit introduces a comprehensive rename and refactoring of the mod from "Crime Remover" to "Crime Adjuster", reflecting its expanded capabilities. Key changes include:

- Renamed classes, methods, and translation keys to use "Adjuster" instead of "Remover"
- Updated settings to support crime percentage scaling (0-300%)
- Modified localization texts to better describe the mod's functionality
- Adjusted system logic to support more flexible crime value modifications
- Updated UI components to reflect the new naming